### PR TITLE
feat(Task): Added pipeIf for conditional piping

### DIFF
--- a/source/task/Task.js
+++ b/source/task/Task.js
@@ -202,7 +202,8 @@ class Task extends Base
      */
     pipeIf(task, condition)
     {
-        if (condition) {
+        if (condition)
+        {
             return this.pipe(task);
         }
         return this;

--- a/source/task/Task.js
+++ b/source/task/Task.js
@@ -191,6 +191,22 @@ class Task extends Base
         return task;
     }
 
+    /**
+     * Conditionally Connects another task to this task so
+     * that it will be executed after this task.
+     * This will call pipe only if the condition is true
+     *
+     * @param {task.Task} task
+     * @param {Bool} condition
+     * @returns {task.Task}
+     */
+    pipeIf(task, condition)
+    {
+        if (condition) {
+            return this.pipe(task);
+        }
+        return this;
+    }
 
     /**
      * Runs the task chain by starting with

--- a/test/task/TaskShared.js
+++ b/test/task/TaskShared.js
@@ -66,6 +66,63 @@ function spec(type, className, prepareParameters, options)
         });
     });
 
+    describe('#pipeIf()', function()
+    {
+        it('should return the piped Task if condition is true', function()
+        {
+            const testee = createTestee();
+            const pipedTestee = createTestee();
+            const result = testee.pipeIf(pipedTestee, true);
+            expect(result).to.be.equal(pipedTestee);
+            return result;
+        });
+
+        it('should return the unchanged pipe if condition is false', function()
+        {
+            const testee = createTestee();
+            const pipedTestee = createTestee();
+            const result = testee.pipeIf(pipedTestee, false);
+            expect(result).to.be.equal(testee);
+            return result;
+        });
+
+        it('should set previousTask on the piped task if condition is true', function()
+        {
+            const testee = createTestee();
+            const pipedTestee = createTestee();
+            const result = testee.pipeIf(pipedTestee, true);
+            expect(pipedTestee.previousTask).to.be.equal(testee);
+            return result;
+        });
+
+        it('should return no previousTask on the piped task if condition is false', function()
+        {
+            const testee = createTestee();
+            const pipedTestee = createTestee();
+            const result = testee.pipeIf(pipedTestee, false);
+            expect(pipedTestee.previousTask).to.be.equal(false);
+            return result;
+        });
+
+        it('should set nextTask on the task if condition is true', function()
+        {
+            const testee = createTestee();
+            const pipedTestee = createTestee();
+            const result = testee.pipeIf(pipedTestee, true);
+            expect(testee.nextTask).to.be.equal(pipedTestee);
+            return result;
+        });
+
+        it('should not set nextTask on the task if condition is false', function()
+        {
+            const testee = createTestee();
+            const pipedTestee = createTestee();
+            const result = testee.pipeIf(pipedTestee, false);
+            expect(testee.nextTask).to.be.equal(false);
+            return result;
+        });
+    });
+
 
     describe('#stream()', function()
     {


### PR DESCRIPTION
Little usefull helper feature to make the piping even more flexibel based on buildConfigs or other conditions influencing a pipeline.

Allows this instead of code duplication or special checks inside a task:

```
yield scope.context.di.create(ExportTask, mapping)
.pipe(scope.context.di.create(EnvironmentTask, mapping))
.pipeIf(scope.context.di.create(BeautifyHtmlTask, mapping), buildConfiguration.get('export.beautify', false))
.pipe(scope.context.di.create(DecorateTask, mapping))
.pipe(scope.context.di.create(ReplaceTask, mapping))
.pipe(scope.context.di.create(WriteFilesTask, mapping))
.run(buildConfiguration, exportOptions);
```